### PR TITLE
Fixed bug in hello_box example.

### DIFF
--- a/examples/hello_box/main.py
+++ b/examples/hello_box/main.py
@@ -51,4 +51,4 @@ for i in range(5):
 
 # Translate all boxes to have xy center at (0, 0)
 boxes_center = compute_bbox_center(all_boxes)
-translate("/scene/boxes", (-boxes_center[0], -boxes_center[1], 0))
+translate(all_boxes, (-boxes_center[0], -boxes_center[1], 0))


### PR DESCRIPTION
Tested on a Windows 10 machine.
With original code the script failed to run and produced following error (I think the problem is that translate() function expects to receive in input an Usd.Prim and not a string):

```
2024-09-23 18:04:45 [192,079ms] [Error] [carb.scripting-python.plugin] ArgumentError: Python argument types in
    Xformable.__init__(Xformable, str)
did not match C++ signature:
    __init__(struct _object * __ptr64, class pxrInternal_v0_22__pxrReserved__::UsdSchemaBase schemaObj)
    __init__(struct _object * __ptr64, class pxrInternal_v0_22__pxrReserved__::UsdPrim prim)
    __init__(struct _object * __ptr64)

At:
  C:\Users\aeusebi/Documents/omniverse/usd_scene_construction_utils\usd_scene_construction_utils.py(609): translate
  c:/users/aeusebi/appdata/local/temp/xsf8.0/script_1727114685.py(57): <module>

ArgumentError: Python argument types in
    Xformable.__init__(Xformable, str)
did not match C++ signature:
    __init__(struct _object * __ptr64, class pxrInternal_v0_22__pxrReserved__::UsdSchemaBase schemaObj)
    __init__(struct _object * __ptr64, class pxrInternal_v0_22__pxrReserved__::UsdPrim prim)
    __init__(struct _object * __ptr64)

At:
  C:\Users\aeusebi/Documents/omniverse/usd_scene_construction_utils\usd_scene_construction_utils.py(609): translate
  c:/users/aeusebi/appdata/local/temp/xsf8.0/script_1727114685.py(57): <module>
2024-09-23 18:04:45 [192,083ms] [Error] [omni.kit.app.plugin] [py stderr]: ArgumentError: Python argument types in
    Xformable.__init__(Xformable, str)
did not match C++ signature:
    __init__(struct _object * __ptr64, class pxrInternal_v0_22__pxrReserved__::UsdSchemaBase schemaObj)
    __init__(struct _object * __ptr64, class pxrInternal_v0_22__pxrReserved__::UsdPrim prim)
    __init__(struct _object * __ptr64)

At:
  C:\Users\aeusebi/Documents/omniverse/usd_scene_construction_utils\usd_scene_construction_utils.py(609): translate
  c:/users/aeusebi/appdata/local/temp/xsf8.0/script_1727114685.py(57): <module>
```