### PR TITLE
Fixed bug in Prims path in Windows.

### DIFF
--- a/examples/hand_truck_w_boxes/main.py
+++ b/examples/hand_truck_w_boxes/main.py
@@ -99,7 +99,7 @@ def add_random_box_stack(
 
     boxes = []
     for i in range(count):
-        box_i = add_box_of_size(stage, os.path.join(path, f"box_{i}"), sizes[i])
+        box_i = add_box_of_size(stage, os.path.join(path + "/" + f"box_{i}"), sizes[i])
         boxes.append(box_i)
 
     if count > 0:
@@ -136,7 +136,7 @@ def add_random_box_stacks(
     stacks = []
     count = random.randint(*count_range)
     for i in range(count):
-        stack, items = add_random_box_stack(stage, os.path.join(path, f"stack_{i}"))
+        stack, items = add_random_box_stack(stage, os.path.join(path + "/" + f"stack_{i}"))
         stacks.append(stack)
 
     for i in range(count):

--- a/examples/pallet_with_boxes/main.py
+++ b/examples/pallet_with_boxes/main.py
@@ -47,8 +47,8 @@ def add_cardboard_box(stage, path: str):
 
 def add_pallet_with_box(stage, path: str):
     container = add_xform(stage, path)
-    pallet = add_pallet(stage, os.path.join(path, "pallet"))
-    box = add_cardboard_box(stage, os.path.join(path, "box"))
+    pallet = add_pallet(stage, os.path.join(path + "/pallet"))
+    box = add_cardboard_box(stage, os.path.join(path + "/box"))
     pallet_bbox = compute_bbox(pallet)
     box_bbox = compute_bbox(box)
     translate(box,(0, 0, pallet_bbox[1][2] - box_bbox[0][2]))

--- a/usd_scene_construction_utils.py
+++ b/usd_scene_construction_utils.py
@@ -90,7 +90,7 @@ def add_usd_ref(stage: Usd.Stage, path: str, usd_path: str) -> Usd.Prim:
     """
 
     stage.DefinePrim(path, "Xform")
-    prim_ref = stage.DefinePrim(os.path.join(path, "ref"))
+    prim_ref = stage.DefinePrim(os.path.join(path + "/ref"))  # Use + to avoid backslash in Windows
     prim_ref.GetReferences().AddReference(usd_path)
 
     return get_prim(stage, path)
@@ -171,7 +171,7 @@ def add_box(stage: Usd.Stage, path: str, size: Tuple[float, float, float]) -> Us
         faceUvMaps) = _make_box_mesh(half_size)
 
     # create mesh at {path}/mesh, but return prim at {path}
-    prim: UsdGeom.Mesh = UsdGeom.Mesh.Define(stage, os.path.join(path, "mesh"))
+    prim: UsdGeom.Mesh = UsdGeom.Mesh.Define(stage, os.path.join(path + "/mesh"))
     prim.CreateExtentAttr().Set([
         (-half_size[0], -half_size[1], -half_size[2]),
         (half_size[0], half_size[1], half_size[2])
@@ -238,7 +238,7 @@ def add_plane(
     stage.DefinePrim(path, "Xform")
     
     # create mesh at {path}/mesh, but return prim at {path}
-    prim: UsdGeom.Mesh = UsdGeom.Mesh.Define(stage, os.path.join(path, "mesh"))
+    prim: UsdGeom.Mesh = UsdGeom.Mesh.Define(stage, os.path.join(path + "/mesh"))
     prim.CreateExtentAttr().Set([
         (-size[0], -size[1], 0),
         (size[0], size[1], 0)


### PR DESCRIPTION
Creating Prim path using strings concatenation instead of automatic joining from os.path lib to avoid Windows separator usage.
In windows the automatic separator is backslash. This will create a wrong path for Omniverse, which I assume it expects the path to be formed by forward slashes only.
Tested on Windows 10.

Please be aware that I didn't check all the occurences in all the examples, I just checked on the three I personally tested (as well as the main library).
Double check other examples as well please.